### PR TITLE
Download the KindleGen archive from GitHub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.11.6@sha256:39eda93d15866957feaee28f8fc5adb545276a64147445c64992ef69804dbf01
 LABEL maintainer "Koen Rouwhorst <info@koenrouwhorst.nl>"
 
-# NOTE: https://www.amazon.com/gp/feature.html?docId=1000765211
+# NOTE: Amazon killed KindleGen https://www.amazon.com/gp/feature.html?docId=1000765211
 ENV KINDLEGEN_VERSION="2.9"
 ENV KINDLEGEN_CHECKSUM="9828db5a2c8970d487ada2caa91a3b6403210d5d183a7e3849b1b206ff042296"
 
@@ -13,7 +13,7 @@ RUN adduser -u 1001 -D kindlegen \
 
 WORKDIR /tmp
 
-RUN curl "https://kindlegen.s3.amazonaws.com/kindlegen_linux_2.6_i386_v${KINDLEGEN_VERSION/\./_}.tar.gz" \
+RUN curl "https://raw.githubusercontent.com/koenrh/docker-kindlegen/master/kindlegen/kindlegen_linux_2.6_i386_v${KINDLEGEN_VERSION/\./_}.tar.gz" \
   -o "kindlegen-$KINDLEGEN_VERSION.tar.gz" \
   && echo "$KINDLEGEN_CHECKSUM  kindlegen-$KINDLEGEN_VERSION.tar.gz" | sha256sum -c - \
   && mkdir -p /app \


### PR DESCRIPTION
Amazon killed KindleGen and the S3 bucket that served the build.